### PR TITLE
fix: Changed regex

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -11,7 +11,7 @@ import { rhythm } from "~/src/styles/typography"
 const About = () => {
   const data = useStaticQuery<Queries.Query>(graphql`
     query About {
-      allMarkdownRemark(filter: { fileAbsolutePath: { regex: "/about/" } }) {
+      allMarkdownRemark(filter: { fileAbsolutePath: { regex: "/.*\/about.md$/" } }) {
         edges {
           node {
             html


### PR DESCRIPTION
This regex no longer pull an incorrect file such as "about_cooking.md," or "about_minecraft.md."