### PR TITLE
style: add table、th、td style

### DIFF
--- a/src/posts/blog/markdown-test.md
+++ b/src/posts/blog/markdown-test.md
@@ -287,3 +287,12 @@ Unlike a pre-formatted code block, a code span indicates code within a
 normal paragraph. For example:
 
 Use the `printf()` function.
+
+### Table
+
+| name          | desc                    |
+| ------------- | ----------------------- |
+| :set number   | show line number        |
+| :set nonumber | do not show line number |
+
+number can be short as "nu"

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -17,6 +17,7 @@ const GlobalStyle = createGlobalStyle`
     --grid-gap-lg: 24px;
     --grid-gap-xl: 36px;
 
+    --padding-xs: 10px;
     --padding-sm: 16px;
     --padding-lg: 22px;
 
@@ -36,7 +37,7 @@ const GlobalStyle = createGlobalStyle`
     --text-base: 1rem;
     --text-md: 1.125rem;
     --text-title: 1.25rem;
-    --text-lg: 1.5rem; 
+    --text-lg: 1.5rem;
     --text-xl: 3rem;
 
     --device-xs-max-width: 419px;

--- a/src/styles/markdown.ts
+++ b/src/styles/markdown.ts
@@ -12,9 +12,16 @@ const Markdown = styled.article<{ rhythm: (typeof typography)["rhythm"] }>`
     font-weight: var(--font-weight-bold);
   }
 
+  table {
+    margin-bottom: var(--sizing-base);
+  }
   td,
   th {
-    border-bottom: 1px solid var(--color-gray-3);
+    padding: var(--padding-xs);
+    border: 1px solid var(--color-gray-3);
+  }
+  th {
+    font-weight: var(--font-weight-semi-bold);
   }
 
   strong {

--- a/src/styles/markdown.ts
+++ b/src/styles/markdown.ts
@@ -93,6 +93,13 @@ const Markdown = styled.article<{ rhythm: (typeof typography)["rhythm"] }>`
     margin-left: ${({ rhythm }) => rhythm(1.25)};
   }
 
+  ol {
+    list-style: auto;
+  }
+  ul {
+    list-style: disc;
+  }
+
   li > ul,
   li > ol {
     margin-top: 0;
@@ -110,6 +117,10 @@ const Markdown = styled.article<{ rhythm: (typeof typography)["rhythm"] }>`
 
   li {
     margin-bottom: ${({ rhythm }) => rhythm(0.3)};
+  }
+
+  li {
+    line-height: 1.68;
   }
 
   p,


### PR DESCRIPTION
# add style for table、th、th

## view diff
### Before
![e976939ad6ad5852dd34121e5ada8a1](https://github.com/sungik-choi/gatsby-starter-apple/assets/15937431/ad5f9563-ad18-4d0e-9c15-570cf197bd75)

### After:
![19f0e7c813af893f1bad4cbfa8e2c38](https://github.com/sungik-choi/gatsby-starter-apple/assets/15937431/727e1fc1-f8e7-4201-bd89-9365d1be0a0c)


#  adjust the style for ul、ol、li
## view diff
### Before
![ol-before](https://github.com/sungik-choi/gatsby-starter-apple/assets/15937431/58bd0bd1-38ec-40ac-bfa9-147ff8662094)

### After
![ol-after](https://github.com/sungik-choi/gatsby-starter-apple/assets/15937431/6b14ca1a-b148-4305-b36d-c9fd6996b3d2)